### PR TITLE
Dashboard workflow code cleanup

### DIFF
--- a/src/ess/livedata/dashboard/configuration_adapter.py
+++ b/src/ess/livedata/dashboard/configuration_adapter.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Generic, TypeVar
+
+Model = TypeVar('Model')
+
+
+class ConfigurationAdapter(ABC, Generic[Model]):
+    """Abstract adapter for providing configuration data to generic widgets."""
+
+    @property
+    @abstractmethod
+    def title(self) -> str:
+        """Configuration title."""
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Configuration description."""
+
+    @property
+    def aux_source_names(self) -> dict[str, list[str]]:
+        """Available auxiliary source names grouped by category."""
+        return {}
+
+    @abstractmethod
+    def model_class(self, aux_source_names: dict[str, str]) -> type[Model] | None:
+        """
+        Pydantic model class for parameters.
+
+        Parameters
+        ----------
+        aux_source_names
+            Selected auxiliary source names by category
+        """
+
+    @property
+    @abstractmethod
+    def source_names(self) -> list[str]:
+        """Available source names."""
+
+    @property
+    @abstractmethod
+    def initial_source_names(self) -> list[str]:
+        """Initially selected source names."""
+
+    @property
+    @abstractmethod
+    def initial_parameter_values(self) -> dict[str, Any]:
+        """Initial parameter values."""
+
+    @abstractmethod
+    def start_action(
+        self, selected_sources: list[str], parameter_values: Model
+    ) -> bool:
+        """
+        Execute the start action with selected sources and parameters.
+
+        Returns
+        -------
+        bool
+            True if successful, False otherwise
+        """

--- a/src/ess/livedata/dashboard/correlation_histogram.py
+++ b/src/ess/livedata/dashboard/correlation_histogram.py
@@ -14,9 +14,9 @@ import scipp as sc
 from ess.livedata.config.workflow_spec import JobId, JobNumber, ResultKey, WorkflowSpec
 from ess.livedata.parameter_models import EdgesModel, make_edges
 
+from .configuration_adapter import ConfigurationAdapter
 from .data_service import DataService
 from .data_subscriber import DataSubscriber, MergingStreamAssembler
-from .widgets.configuration_widget import ConfigurationAdapter
 
 
 class EdgesWithUnit(EdgesModel):

--- a/src/ess/livedata/dashboard/widgets/configuration_widget.py
+++ b/src/ess/livedata/dashboard/widgets/configuration_widget.py
@@ -2,74 +2,14 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Any, Generic, TypeVar
 
 import panel as pn
 import pydantic
 
+from ess.livedata.dashboard.configuration_adapter import ConfigurationAdapter
+
 from .model_widget import ModelWidget
-
-Model = TypeVar('Model')
-
-
-class ConfigurationAdapter(ABC, Generic[Model]):
-    """Abstract adapter for providing configuration data to generic widgets."""
-
-    @property
-    @abstractmethod
-    def title(self) -> str:
-        """Configuration title."""
-
-    @property
-    @abstractmethod
-    def description(self) -> str:
-        """Configuration description."""
-
-    @property
-    def aux_source_names(self) -> dict[str, list[str]]:
-        """Available auxiliary source names grouped by category."""
-        return {}
-
-    @abstractmethod
-    def model_class(self, aux_source_names: dict[str, str]) -> type[Model] | None:
-        """
-        Pydantic model class for parameters.
-
-        Parameters
-        ----------
-        aux_source_names
-            Selected auxiliary source names by category
-        """
-
-    @property
-    @abstractmethod
-    def source_names(self) -> list[str]:
-        """Available source names."""
-
-    @property
-    @abstractmethod
-    def initial_source_names(self) -> list[str]:
-        """Initially selected source names."""
-
-    @property
-    @abstractmethod
-    def initial_parameter_values(self) -> dict[str, Any]:
-        """Initial parameter values."""
-
-    @abstractmethod
-    def start_action(
-        self, selected_sources: list[str], parameter_values: Model
-    ) -> bool:
-        """
-        Execute the start action with selected sources and parameters.
-
-        Returns
-        -------
-        bool
-            True if successful, False otherwise
-        """
 
 
 class ConfigurationWidget:

--- a/src/ess/livedata/dashboard/widgets/plot_creation_widget.py
+++ b/src/ess/livedata/dashboard/widgets/plot_creation_widget.py
@@ -9,12 +9,13 @@ import panel as pn
 import pydantic
 
 from ess.livedata.config.workflow_spec import JobNumber
+from ess.livedata.dashboard.configuration_adapter import ConfigurationAdapter
 from ess.livedata.dashboard.job_controller import JobController
 from ess.livedata.dashboard.job_service import JobService
 from ess.livedata.dashboard.plotting import PlotterSpec
 from ess.livedata.dashboard.plotting_controller import PlottingController
 
-from .configuration_widget import ConfigurationAdapter, ConfigurationModal
+from .configuration_widget import ConfigurationModal
 from .job_status_widget import JobStatusListWidget
 
 

--- a/src/ess/livedata/dashboard/widgets/reduction_widget.py
+++ b/src/ess/livedata/dashboard/widgets/reduction_widget.py
@@ -26,13 +26,15 @@ from __future__ import annotations
 import panel as pn
 
 from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
+from ess.livedata.dashboard.workflow_configuation_adapter import (
+    WorkflowConfigurationAdapter,
+)
 from ess.livedata.dashboard.workflow_controller import (
     BoundWorkflowController,
     WorkflowController,
 )
 
 from .configuration_widget import ConfigurationModal
-from .workflow_config_modal import WorkflowConfigurationAdapter
 
 
 class WorkflowSelectorWidget:

--- a/src/ess/livedata/dashboard/widgets/reduction_widget.py
+++ b/src/ess/livedata/dashboard/widgets/reduction_widget.py
@@ -31,7 +31,8 @@ from ess.livedata.dashboard.workflow_controller import (
     WorkflowController,
 )
 
-from .workflow_config_modal import WorkflowConfigModal
+from .configuration_widget import ConfigurationModal
+from .workflow_config_modal import WorkflowConfigurationAdapter
 
 
 class WorkflowSelectorWidget:
@@ -121,11 +122,12 @@ class WorkflowSelectorWidget:
         value = self._selector.value
         return None if self._is_no_selection(value) else value
 
-    def create_modal(self) -> WorkflowConfigModal | None:
+    def create_modal(self) -> ConfigurationModal | None:
         if self._bound_controller is None:
-            return
+            return None
 
-        return WorkflowConfigModal(controller=self._bound_controller)
+        adapter = WorkflowConfigurationAdapter(self._bound_controller)
+        return ConfigurationModal(config=adapter, start_button_text="Start Workflow")
 
 
 class ReductionWidget:

--- a/src/ess/livedata/dashboard/widgets/reduction_widget.py
+++ b/src/ess/livedata/dashboard/widgets/reduction_widget.py
@@ -180,7 +180,8 @@ class ReductionWidget:
         if (modal := self._workflow_selector.create_modal()) is None:
             return
 
-        # Add modal to container and show it
+        # Clear previous modals and add the new one
+        self._modal_container.clear()
         self._modal_container.append(modal.modal)
         modal.show()
 

--- a/src/ess/livedata/dashboard/widgets/workflow_config_modal.py
+++ b/src/ess/livedata/dashboard/widgets/workflow_config_modal.py
@@ -4,16 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-import panel as pn
 import pydantic
 
 from ess.livedata.dashboard.workflow_controller import BoundWorkflowController
 
-from .configuration_widget import (
-    ConfigurationAdapter,
-    ConfigurationModal,
-    ConfigurationWidget,
-)
+from .configuration_widget import ConfigurationAdapter
 
 
 class WorkflowConfigurationAdapter(ConfigurationAdapter):
@@ -66,71 +61,3 @@ class WorkflowConfigurationAdapter(ConfigurationAdapter):
     def start_action(self, selected_sources: list[str], parameter_values: Any) -> bool:
         """Start the workflow with given sources and parameters."""
         return self._controller.start_workflow(selected_sources, parameter_values)
-
-
-class WorkflowConfigWidget:
-    """Widget for configuring workflow parameters and source selection."""
-
-    def __init__(self, controller: BoundWorkflowController) -> None:
-        """
-        Initialize workflow configuration widget.
-
-        Parameters
-        ----------
-        controller
-            Controller bound to a specific workflow
-        """
-        self._adapter = WorkflowConfigurationAdapter(controller)
-        self._generic_widget = ConfigurationWidget(self._adapter)
-
-    @property
-    def widget(self):
-        """Get the Panel widget."""
-        return self._generic_widget.widget
-
-    @property
-    def selected_sources(self) -> list[str]:
-        """Get the selected source names."""
-        return self._generic_widget.selected_sources
-
-    @property
-    def parameter_values(self):
-        """Get current parameter values as a model instance."""
-        return self._generic_widget.parameter_values
-
-    def validate_configuration(self) -> tuple[bool, list[str]]:
-        """Validate that required fields are configured."""
-        return self._generic_widget.validate_configuration()
-
-    def clear_validation_errors(self) -> None:
-        """Clear all validation error states."""
-        self._generic_widget.clear_validation_errors()
-
-
-class WorkflowConfigModal:
-    """Modal dialog for workflow configuration."""
-
-    def __init__(self, controller: BoundWorkflowController) -> None:
-        """
-        Initialize workflow configuration modal.
-
-        Parameters
-        ----------
-        controller
-            Controller bound to a specific workflow
-        """
-        self._controller = controller
-        self._adapter = WorkflowConfigurationAdapter(controller)
-        self._generic_modal = ConfigurationModal(
-            config=self._adapter,
-            start_button_text="Start Workflow",
-        )
-
-    def show(self) -> None:
-        """Show the modal dialog."""
-        self._generic_modal.show()
-
-    @property
-    def modal(self) -> pn.Modal:
-        """Get the modal widget."""
-        return self._generic_modal.modal

--- a/src/ess/livedata/dashboard/workflow_configuation_adapter.py
+++ b/src/ess/livedata/dashboard/workflow_configuation_adapter.py
@@ -19,7 +19,8 @@ class WorkflowConfigurationAdapter(ConfigurationAdapter):
         """Initialize adapter with workflow controller and ID."""
         self._controller = controller
         self._workflow_id = workflow_id
-        if (spec := controller.get_workflow_spec(workflow_id)) is None:
+        spec = controller.get_workflow_spec(workflow_id)
+        if spec is None:
             raise ValueError(f'Workflow {workflow_id} not found')
         self._spec = spec
 

--- a/src/ess/livedata/dashboard/workflow_configuation_adapter.py
+++ b/src/ess/livedata/dashboard/workflow_configuation_adapter.py
@@ -8,7 +8,7 @@ import pydantic
 
 from ess.livedata.dashboard.workflow_controller import BoundWorkflowController
 
-from .configuration_widget import ConfigurationAdapter
+from .configuration_adapter import ConfigurationAdapter
 
 
 class WorkflowConfigurationAdapter(ConfigurationAdapter):

--- a/src/ess/livedata/dashboard/workflow_configuation_adapter.py
+++ b/src/ess/livedata/dashboard/workflow_configuation_adapter.py
@@ -6,58 +6,65 @@ from typing import Any
 
 import pydantic
 
-from ess.livedata.dashboard.workflow_controller import BoundWorkflowController
+from ess.livedata.config.workflow_spec import WorkflowId
+from ess.livedata.dashboard.workflow_controller import WorkflowController
 
 from .configuration_adapter import ConfigurationAdapter
 
 
 class WorkflowConfigurationAdapter(ConfigurationAdapter):
-    """Adapter for workflow configuration using BoundWorkflowController."""
+    """Adapter for workflow configuration using WorkflowController."""
 
-    def __init__(self, controller: BoundWorkflowController) -> None:
-        """Initialize adapter with workflow controller."""
+    def __init__(self, controller: WorkflowController, workflow_id: WorkflowId) -> None:
+        """Initialize adapter with workflow controller and ID."""
         self._controller = controller
+        self._workflow_id = workflow_id
+        if (spec := controller.get_workflow_spec(workflow_id)) is None:
+            raise ValueError(f'Workflow {workflow_id} not found')
+        self._spec = spec
 
     @property
     def title(self) -> str:
         """Get workflow title."""
-        return self._controller.spec.title
+        return self._spec.title
 
     @property
     def description(self) -> str:
         """Get workflow description."""
-        return self._controller.spec.description
+        return self._spec.description
 
     @property
     def aux_source_names(self) -> dict[str, list[str]]:
         """Get auxiliary source names with unique options."""
-        return {key: [key] for key in self._controller.spec.aux_source_names}
+        return {key: [key] for key in self._spec.aux_source_names}
 
     def model_class(
         self, aux_source_names: dict[str, str]
     ) -> type[pydantic.BaseModel] | None:
         """Get workflow parameters model class."""
-        return self._controller.params_model_class
+        return self._spec.params
 
     @property
     def source_names(self) -> list[str]:
         """Get available source names."""
-        return self._controller.spec.source_names
+        return self._spec.source_names
 
     @property
     def initial_source_names(self) -> list[str]:
         """Get initial source names."""
-        persistent_config = self._controller.get_persistent_config()
+        persistent_config = self._controller.get_workflow_config(self._workflow_id)
         return persistent_config.source_names if persistent_config else []
 
     @property
     def initial_parameter_values(self) -> dict[str, Any]:
         """Get initial parameter values."""
-        persistent_config = self._controller.get_persistent_config()
+        persistent_config = self._controller.get_workflow_config(self._workflow_id)
         if not persistent_config:
             return {}
         return persistent_config.config.params
 
     def start_action(self, selected_sources: list[str], parameter_values: Any) -> bool:
         """Start the workflow with given sources and parameters."""
-        return self._controller.start_workflow(selected_sources, parameter_values)
+        return self._controller.start_workflow(
+            self._workflow_id, selected_sources, parameter_values
+        )

--- a/src/ess/livedata/dashboard/workflow_controller.py
+++ b/src/ess/livedata/dashboard/workflow_controller.py
@@ -185,23 +185,29 @@ class WorkflowController:
 
         return True
 
-    def get_workflow_specs(self) -> dict[WorkflowId, WorkflowSpec]:
-        """Get the current workflow specifications sorted by title."""
-        return dict(
-            sorted(self._workflow_registry.items(), key=lambda item: item[1].title)
-        )
+    def create_workflow_adapter(self, workflow_id: WorkflowId):
+        """Create a workflow configuration adapter for the given workflow ID."""
+        from .workflow_configuation_adapter import WorkflowConfigurationAdapter
+
+        return WorkflowConfigurationAdapter(self, workflow_id)
+
+    def get_workflow_titles(self) -> dict[WorkflowId, str]:
+        """Get workflow IDs mapped to their titles, sorted by title."""
+        return {
+            workflow_id: spec.title
+            for workflow_id, spec in sorted(
+                self._workflow_registry.items(), key=lambda item: item[1].title
+            )
+        }
+
+    def get_workflow_description(self, workflow_id: WorkflowId) -> str | None:
+        """Get the description for the given workflow ID."""
+        spec = self._workflow_registry.get(workflow_id)
+        return spec.description if spec else None
 
     def get_workflow_spec(self, workflow_id: WorkflowId) -> WorkflowSpec | None:
         """Get the current workflow specification for the given Id."""
         return self._workflow_registry.get(workflow_id)
-
-    def get_workflow_params(
-        self, workflow_id: WorkflowId
-    ) -> type[pydantic.BaseModel] | None:
-        """Get the parameters for the given workflow Id."""
-        if (workflow_spec := self.get_workflow_spec(workflow_id)) is None:
-            return None
-        return workflow_spec.params
 
     def get_workflow_config(
         self, workflow_id: WorkflowId

--- a/src/ess/livedata/dashboard/workflow_controller.py
+++ b/src/ess/livedata/dashboard/workflow_controller.py
@@ -26,64 +26,6 @@ from .data_service import DataService
 from .workflow_config_service import ConfigServiceAdapter, WorkflowConfigService
 
 
-class BoundWorkflowController:
-    """
-    Controller bound to a specific workflow, providing direct access without ID checks.
-
-    This controller is created from a main WorkflowController and provides a simplified
-    interface for widgets that work with a single workflow.
-    """
-
-    def __init__(
-        self,
-        workflow_id: WorkflowId,
-        spec: WorkflowSpec,
-        main_controller: WorkflowController,
-    ) -> None:
-        """
-        Initialize bound controller.
-
-        Parameters
-        ----------
-        workflow_id
-            The workflow ID this controller is bound to
-        spec
-            The workflow specification
-        main_controller
-            Reference to the main controller for operations
-        """
-        self._workflow_id = workflow_id
-        self._spec = spec
-        self._main_controller = main_controller
-
-    @property
-    def workflow_id(self) -> WorkflowId:
-        """Get the workflow ID."""
-        return self._workflow_id
-
-    @property
-    def spec(self) -> WorkflowSpec:
-        """Get the workflow specification."""
-        return self._spec
-
-    @property
-    def params_model_class(self) -> type[pydantic.BaseModel]:
-        """Get the parameters model class."""
-        return self._spec.params
-
-    def get_persistent_config(self) -> PersistentWorkflowConfig | None:
-        """Get persistent configuration for this workflow."""
-        return self._main_controller.get_workflow_config(self._workflow_id)
-
-    def start_workflow(
-        self, source_names: list[str], config: pydantic.BaseModel
-    ) -> bool:
-        """Start this workflow with given configuration."""
-        return self._main_controller.start_workflow(
-            self._workflow_id, source_names, config
-        )
-
-
 class WorkflowController:
     """
     Workflow controller backed by a config service.
@@ -282,23 +224,3 @@ class WorkflowController:
             callback(self._workflow_status.copy())
         except Exception as e:
             self._logger.error('Error in workflow status update callback: %s', e)
-
-    def get_bound_controller(
-        self, workflow_id: WorkflowId
-    ) -> BoundWorkflowController | None:
-        """
-        Get a controller bound to a specific workflow.
-
-        Parameters
-        ----------
-        workflow_id
-            ID of the workflow to bind to
-
-        Returns
-        -------
-        BoundWorkflowController | None
-            Bound controller if workflow exists, None otherwise
-        """
-        if (spec := self.get_workflow_spec(workflow_id)) is None:
-            return None
-        return BoundWorkflowController(workflow_id, spec, self)


### PR DESCRIPTION
A bunch of cleanup. Some wrappers did not make sense any more after we introduced the generic `ConfigurationAdapter` mechanism (but it was overlooked that this could be cleaned up). See individual commits.

The motivation for this cleanup is that I would like to merge to bespoke "correlation histogram widget" with the main workflow selection dropdown. I hope this will be easier after this.