### PR TITLE
Do not use auto.offset.reset: earliest in backend

### DIFF
--- a/src/ess/livedata/config/defaults/control_consumer.yaml
+++ b/src/ess/livedata/config/defaults/control_consumer.yaml
@@ -1,6 +1,10 @@
-# The control topic is compacted, we to set auto.offset.reset to earliest
-# to get config values that were set in the past
-auto.offset.reset: earliest
+# The control topic is compacted, we can set auto.offset.reset to earliest
+# to get config values that were set in the past. This is currently not enabled, since
+# workflow start commands are still on this topic, leading to duplicate and "zombie"
+# jobs across backend restarts in some cases. The dashboard manually configures the
+# offset to "earliest" when reading the control topic since it uses the topic for
+# storing previous workflow configurations.
+auto.offset.reset: latest
 enable.auto.commit: true
 fetch.min.bytes: 1
 session.timeout.ms: 6000

--- a/src/ess/livedata/dashboard/dashboard.py
+++ b/src/ess/livedata/dashboard/dashboard.py
@@ -92,7 +92,10 @@ class DashboardBase(ServiceBase, ABC):
         """Set up configuration service with Kafka bridge."""
         kafka_downstream_config = load_config(namespace=config_names.kafka_downstream)
         _, consumer = self._exit_stack.enter_context(
-            kafka_consumer.make_control_consumer(instrument=self._instrument)
+            kafka_consumer.make_control_consumer(
+                instrument=self._instrument,
+                extra_config={'auto.offset.reset': 'earliest'},
+            )
         )
         kafka_transport = KafkaTransport(
             kafka_config=kafka_downstream_config, consumer=consumer, logger=self._logger

--- a/src/ess/livedata/kafka/consumer.py
+++ b/src/ess/livedata/kafka/consumer.py
@@ -70,14 +70,16 @@ def make_consumer_from_config(
 
 @contextmanager
 def make_control_consumer(
-    *, instrument: str
+    *,
+    instrument: str,
+    extra_config: dict[str, Any] | None = None,
 ) -> Generator[str, kafka.Consumer, None, None]:
     control_config = load_config(namespace='control_consumer', env='')
     kafka_downstream_config = load_config(namespace='kafka_downstream')
     topic = stream_kind_to_topic(instrument=instrument, kind=StreamKind.LIVEDATA_CONFIG)
     with make_consumer_from_config(
         topics=[topic],
-        config={**control_config, **kafka_downstream_config},
+        config={**control_config, **kafka_downstream_config, **(extra_config or {})},
         group='livedata_commands',
     ) as consumer:
         yield topic, consumer


### PR DESCRIPTION
See the added comment about why this causes trouble. #445 might address some issues from the dual use of the topic, we can revisit this then.

The consequence from this change is that jobs are not automatically recreated if the backend crashes/restarts.