### PR TITLE
Add support for explicit aux sources in WorkflowSpec and WorkflowConfig

### DIFF
--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -5,14 +5,57 @@ from __future__ import annotations
 from collections import UserDict
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
 import scipp as sc
 import scippnexus as snx
+from pydantic import BaseModel, Field
 
 from ess.livedata.handlers.workflow_factory import Workflow, WorkflowFactory
 
 from .workflow_spec import WorkflowSpec
+
+
+def _create_aux_sources_model_from_list(
+    aux_source_names: Sequence[str],
+) -> type[BaseModel]:
+    """
+    Create an aux_sources Pydantic model from a list of aux source names.
+
+    This is for backward compatibility with the old aux_source_names parameter.
+    Each aux source name becomes a field with a single choice (Literal type).
+
+    Parameters
+    ----------
+    aux_source_names:
+        List of auxiliary source names.
+
+    Returns
+    -------
+    :
+        A Pydantic model class with fields for each aux source.
+    """
+    # Create enum for each aux source name (single value for backward compat)
+    fields = {}
+    for source_name in aux_source_names:
+        # Create an Enum with a single value
+        enum_class = Enum(f'{source_name}_Choice', {source_name.upper(): source_name})
+        # Add field with the enum type and default value
+        fields[source_name] = (
+            enum_class,
+            Field(default=getattr(enum_class, source_name.upper()), title=source_name),
+        )
+
+    # Create the Pydantic model dynamically
+    return type(
+        'AuxSources',
+        (BaseModel,),
+        {
+            '__annotations__': {k: v[0] for k, v in fields.items()},
+            **{k: v[1] for k, v in fields.items()},
+        },
+    )
 
 
 class InstrumentRegistry(UserDict[str, 'Instrument']):
@@ -132,11 +175,14 @@ class Instrument:
         registers the factory with the processor factory and returns the factory
         function unchanged.
 
-        The factory function may have two parameters:
+        The factory function may have up to three parameters:
         - `source_name`: The name of the source to process.
         - `params`: A Pydantic model containing parameters for the workflow. The factory
           inspects the type hint of the `params` parameter to determine the correct
           model that the frontend uses to create workflow configuration widgets.
+        - `aux_sources`: A Pydantic model containing auxiliary source selections. The
+          factory inspects the type hint of the `aux_sources` parameter to determine
+          the available auxiliary sources and their configuration options.
 
         Parameters
         ----------
@@ -153,12 +199,19 @@ class Instrument:
             Optional list of source names that the factory can handle. This is used to
             create a workflow specification.
         aux_source_names:
-            List of auxiliary source names that the workflow needs.
+            DEPRECATED: Use type hints on the factory function's `aux_sources` parameter
+            instead. This parameter is kept for backward compatibility and will
+            automatically convert to the new aux_sources schema.
 
         Returns
         -------
         Decorator function that registers the factory and returns it unchanged.
         """
+        # Backward compatibility: convert old aux_source_names list to new aux_sources
+        aux_sources = None
+        if aux_source_names:
+            aux_sources = _create_aux_sources_model_from_list(aux_source_names)
+
         spec = WorkflowSpec(
             instrument=self.name,
             namespace=namespace,
@@ -168,7 +221,7 @@ class Instrument:
             description=description,
             source_names=list(source_names or []),
             params=None,  # placeholder, filled in from type hint later
-            aux_source_names=list(aux_source_names or []),
+            aux_sources=aux_sources,  # may be set from backward compat or type hint
         )
         return self.workflow_factory.register(spec)
 

--- a/src/ess/livedata/config/instruments/_bifrost_qmap.py
+++ b/src/ess/livedata/config/instruments/_bifrost_qmap.py
@@ -4,6 +4,7 @@
 
 from enum import StrEnum
 from functools import cache
+from typing import Literal
 
 import pydantic
 import sciline
@@ -166,6 +167,19 @@ class BifrostCustomElasticQMapParams(pydantic.BaseModel):
         return CutAxis.from_q_vector(output=name, vec=vec, bins=edges)
 
 
+class BifrostAuxSources(pydantic.BaseModel):
+    """Auxiliary source names for Bifrost Q-map workflows."""
+
+    detector_rotation: Literal['detector_rotation'] = pydantic.Field(
+        default='detector_rotation',
+        description='Detector rotation angle stream for instrument geometry.',
+    )
+    sample_rotation: Literal['sample_rotation'] = pydantic.Field(
+        default='sample_rotation',
+        description='Sample rotation angle stream for instrument geometry.',
+    )
+
+
 def register_qmap_workflows(
     instrument: Instrument,
 ) -> None:
@@ -175,9 +189,10 @@ def register_qmap_workflows(
         title='Q map',
         description='Map of scattering intensity as function of Q and energy transfer.',
         source_names=['unified_detector'],
-        aux_source_names=['detector_rotation', 'sample_rotation'],
     )
-    def _qmap_workflow(params: BifrostQMapParams) -> StreamProcessorWorkflow:
+    def _qmap_workflow(
+        params: BifrostQMapParams, aux_sources: BifrostAuxSources
+    ) -> StreamProcessorWorkflow:
         wf = _get_q_cut_workflow()
         wf[CutAxis1] = params.get_q_cut()
         wf[CutAxis2] = params.get_energy_cut()
@@ -189,10 +204,9 @@ def register_qmap_workflows(
         title='Elastic Q map',
         description='Elastic Q map with predefined axes.',
         source_names=['unified_detector'],
-        aux_source_names=['detector_rotation', 'sample_rotation'],
     )
     def _elastic_qmap_workflow(
-        params: BifrostElasticQMapParams,
+        params: BifrostElasticQMapParams, aux_sources: BifrostAuxSources
     ) -> StreamProcessorWorkflow:
         wf = _get_q_cut_workflow()
         wf[CutAxis1] = params.axis1.to_cut_axis()
@@ -205,10 +219,9 @@ def register_qmap_workflows(
         title='Elastic Q map (custom)',
         description='Elastic Q map with custom axes.',
         source_names=['unified_detector'],
-        aux_source_names=['detector_rotation', 'sample_rotation'],
     )
     def _custom_elastic_qmap_workflow(
-        params: BifrostCustomElasticQMapParams,
+        params: BifrostCustomElasticQMapParams, aux_sources: BifrostAuxSources
     ) -> StreamProcessorWorkflow:
         wf = _get_q_cut_workflow()
         wf[CutAxis1] = params.get_cut_axis1()

--- a/src/ess/livedata/config/instruments/dream.py
+++ b/src/ess/livedata/config/instruments/dream.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 
-from typing import NewType
+from typing import Literal, NewType
 
 import pydantic
 import scipp as sc
@@ -211,6 +211,15 @@ class InstrumentConfiguration(pydantic.BaseModel):
         return self
 
 
+class DreamAuxSources(pydantic.BaseModel):
+    """Auxiliary source names for DREAM powder workflows."""
+
+    cave_monitor: Literal['monitor1'] = pydantic.Field(
+        default='monitor1',
+        description='Cave monitor stream for normalization.',
+    )
+
+
 class PowderWorkflowParams(pydantic.BaseModel):
     dspacing_edges: parameter_models.DspacingEdges = pydantic.Field(
         title='d-spacing bins',
@@ -249,9 +258,10 @@ class PowderWorkflowParams(pydantic.BaseModel):
     title='Powder reduction',
     description='Powder reduction without vanadium normalization.',
     source_names=_source_names,
-    aux_source_names=['monitor1'],
 )
-def _powder_workflow(source_name: str, params: PowderWorkflowParams) -> Workflow:
+def _powder_workflow(
+    source_name: str, params: PowderWorkflowParams, aux_sources: DreamAuxSources
+) -> Workflow:
     wf = _reduction_workflow.copy()
     wf[NeXusName[NXdetector]] = source_name
     wf[dream.InstrumentConfiguration] = params.instrument_configuration.value
@@ -264,7 +274,7 @@ def _powder_workflow(source_name: str, params: PowderWorkflowParams) -> Workflow
         wf,
         dynamic_keys={
             source_name: NeXusData[NXdetector, SampleRun],
-            'monitor1': NeXusData[powder.types.CaveMonitor, SampleRun],
+            'cave_monitor': NeXusData[powder.types.CaveMonitor, SampleRun],
         },
         target_keys=(
             powder.types.FocussedDataDspacing[SampleRun],
@@ -283,10 +293,9 @@ def _powder_workflow(source_name: str, params: PowderWorkflowParams) -> Workflow
     title='Powder reduction (with vanadium)',
     description='Powder reduction with vanadium normalization.',
     source_names=_source_names,
-    aux_source_names=['monitor1'],
 )
 def _powder_workflow_with_vanadium(
-    source_name: str, params: PowderWorkflowParams
+    source_name: str, params: PowderWorkflowParams, aux_sources: DreamAuxSources
 ) -> StreamProcessorWorkflow:
     wf = _reduction_workflow.copy()
     wf[NeXusName[NXdetector]] = source_name
@@ -301,7 +310,7 @@ def _powder_workflow_with_vanadium(
         wf,
         dynamic_keys={
             source_name: NeXusData[NXdetector, SampleRun],
-            'monitor1': NeXusData[powder.types.CaveMonitor, SampleRun],
+            'cave_monitor': NeXusData[powder.types.CaveMonitor, SampleRun],
         },
         target_keys=(
             powder.types.FocussedDataDspacing[SampleRun],

--- a/src/ess/livedata/config/instruments/loki.py
+++ b/src/ess/livedata/config/instruments/loki.py
@@ -20,7 +20,7 @@ from ess.livedata.handlers.monitor_data_handler import register_monitor_workflow
 from ess.livedata.handlers.stream_processor_workflow import StreamProcessorWorkflow
 from ess.livedata.kafka import InputStreamKey, StreamLUT, StreamMapping
 from ess.reduce.nexus.types import NeXusData, NeXusDetectorName, SampleRun
-from ess.sans import types as params
+from ess.sans import types as sans_types
 from ess.sans.types import (
     Filename,
     Incident,
@@ -128,8 +128,10 @@ _xy_projection = DetectorProjection(
 
 
 def _transmission_from_current_run(
-    data: params.CleanMonitor[SampleRun, params.MonitorType],
-) -> params.CleanMonitor[params.TransmissionRun[SampleRun], params.MonitorType]:
+    data: sans_types.CleanMonitor[SampleRun, sans_types.MonitorType],
+) -> sans_types.CleanMonitor[
+    sans_types.TransmissionRun[SampleRun], sans_types.MonitorType
+]:
     return data
 
 
@@ -143,8 +145,8 @@ def _dynamic_keys(source_name: str) -> dict[str, sciline.typing.Key]:
 
 _accumulators = (
     ReducedQ[SampleRun, Numerator],
-    params.CleanMonitor[SampleRun, Incident],
-    params.CleanMonitor[SampleRun, Transmission],
+    sans_types.CleanMonitor[SampleRun, Incident],
+    sans_types.CleanMonitor[SampleRun, Transmission],
 )
 
 
@@ -178,11 +180,11 @@ def _i_of_q_with_params(
     wf = _base_workflow.copy()
     wf[NeXusDetectorName] = source_name
 
-    wf[params.QBins] = params.q_edges.get_edges()
-    wf[params.WavelengthBins] = params.wavelength_edges.get_edges()
+    wf[sans_types.QBins] = params.q_edges.get_edges()
+    wf[sans_types.WavelengthBins] = params.wavelength_edges.get_edges()
 
     if not params.options.use_transmission_run:
-        target_keys = (IofQ[SampleRun], params.TransmissionFraction[SampleRun])
+        target_keys = (IofQ[SampleRun], sans_types.TransmissionFraction[SampleRun])
         wf.insert(_transmission_from_current_run)
     else:
         # Transmission fraction is static, do not display

--- a/src/ess/livedata/config/workflow_spec.py
+++ b/src/ess/livedata/config/workflow_spec.py
@@ -83,9 +83,14 @@ class WorkflowSpec(BaseModel):
         default_factory=list,
         description="List of detector/other streams the workflow can be applied to.",
     )
-    aux_source_names: list[str] = Field(
-        default_factory=list,
-        description="List of auxiliary data streams the workflow needs.",
+    aux_sources: type[BaseModel] | None = Field(
+        default=None,
+        description=(
+            "Pydantic model defining auxiliary data sources with their configuration. "
+            "Field names define the aux source identifiers, and field types (typically "
+            "Literal or Enum) define the available stream choices. Field metadata "
+            "(title, description) provides UI information."
+        ),
     )
     params: type[BaseModel] | None = Field(description="Model for workflow param.")
 
@@ -153,6 +158,13 @@ class WorkflowConfig(BaseModel):
     )
     schedule: JobSchedule = Field(
         default_factory=JobSchedule, description="Schedule for the workflow."
+    )
+    aux_source_names: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Selected auxiliary source names as a mapping from field name (as defined "
+            "in WorkflowSpec.aux_sources) to the selected stream name."
+        ),
     )
     params: dict[str, Any] = Field(
         default_factory=dict,

--- a/src/ess/livedata/config/workflow_spec.py
+++ b/src/ess/livedata/config/workflow_spec.py
@@ -171,6 +171,43 @@ class WorkflowConfig(BaseModel):
         description="Parameters for the workflow, as JSON-serialized Pydantic model.",
     )
 
+    @classmethod
+    def from_params(
+        cls,
+        workflow_id: WorkflowId,
+        params: BaseModel | None = None,
+        aux_source_names: dict[str, str] | None = None,
+        job_number: JobNumber | None = None,
+    ) -> WorkflowConfig:
+        """
+        Create a WorkflowConfig from validated Pydantic models.
+
+        This is a convenience constructor that handles the serialization of params
+        from a Pydantic model to a dict, matching what the controller does.
+
+        Parameters
+        ----------
+        workflow_id
+            Identifier for the workflow
+        params
+            Validated Pydantic model with workflow parameters, or None if no params
+        aux_source_names
+            Selected auxiliary source names, or None if no aux sources
+        job_number
+            Optional job number (generated if not provided)
+
+        Returns
+        -------
+        :
+            WorkflowConfig instance ready to be sent to backend
+        """
+        return cls(
+            identifier=workflow_id,
+            job_number=job_number if job_number is not None else uuid.uuid4(),
+            aux_source_names=aux_source_names or {},
+            params=params.model_dump() if params is not None else {},
+        )
+
 
 class PersistentWorkflowConfig(BaseModel):
     """

--- a/src/ess/livedata/config/workflows.py
+++ b/src/ess/livedata/config/workflows.py
@@ -115,7 +115,6 @@ def register_monitor_timeseries_workflows(
         description='Timeseries of counts in a monitor within a specified '
         'time-of-arrival range.',
         source_names=source_names,
-        aux_source_names=[],
     )
     def monitor_timeseries_workflow(
         source_name: str, params: MonitorTimeseriesParams

--- a/src/ess/livedata/core/job.py
+++ b/src/ess/livedata/core/job.py
@@ -105,7 +105,7 @@ class Job:
         workflow_id: WorkflowId,
         processor: Workflow,
         source_names: list[str],
-        aux_source_names: dict[str, str] | list[str] | None = None,
+        aux_source_names: dict[str, str] | None = None,
     ) -> None:
         """
         Initialize a Job with the given parameters.
@@ -121,10 +121,8 @@ class Job:
         source_names:
             The names of the primary data sources for this job.
         aux_source_names:
-            Auxiliary data sources for this job. Can be either:
-            - dict[str, str]: Mapping from field names to stream names (new schema)
-            - list[str]: Stream names only (backward compatibility)
-            - None: No auxiliary sources
+            Mapping from field names to stream names for auxiliary data sources.
+            None if no auxiliary sources are needed.
         """
         self._job_id = job_id
         self._workflow_id = workflow_id
@@ -132,15 +130,7 @@ class Job:
         self._start_time: int | None = None
         self._end_time: int | None = None
         self._source_names = source_names
-
-        # Handle both dict (new schema) and list (backward compat) formats
-        if aux_source_names is None:
-            self._aux_source_mapping: dict[str, str] = {}
-        elif isinstance(aux_source_names, dict):
-            self._aux_source_mapping = aux_source_names
-        else:
-            # Backward compatibility: list[str] means field names == stream names
-            self._aux_source_mapping = {name: name for name in aux_source_names}
+        self._aux_source_mapping: dict[str, str] = aux_source_names or {}
 
     @property
     def job_id(self) -> JobId:

--- a/src/ess/livedata/core/job_manager.py
+++ b/src/ess/livedata/core/job_manager.py
@@ -77,7 +77,7 @@ class JobFactory:
             raise DifferentInstrument()
 
         factory = self._instrument.workflow_factory
-        if (workflow_spec := factory.get(workflow_id)) is None:
+        if factory.get(workflow_id) is None:
             raise WorkflowNotFoundError(f"WorkflowSpec with Id {workflow_id} not found")
         # Note that this initializes the job immediately, i.e., we pay startup cost now.
         stream_processor = factory.create(source_name=job_id.source_name, config=config)
@@ -86,7 +86,9 @@ class JobFactory:
             workflow_id=workflow_id,
             processor=stream_processor,
             source_names=[job_id.source_name],
-            aux_source_names=workflow_spec.aux_source_names,
+            # Pass aux source names as dict (field name -> stream name mapping)
+            # Job will use values for routing and remap keys for workflow
+            aux_source_names=config.aux_source_names,
         )
 
 

--- a/src/ess/livedata/dashboard/configuration_adapter.py
+++ b/src/ess/livedata/dashboard/configuration_adapter.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
+from pydantic import BaseModel
+
 Model = TypeVar('Model')
 
 
@@ -22,8 +24,24 @@ class ConfigurationAdapter(ABC, Generic[Model]):
         """Configuration description."""
 
     @property
-    def aux_source_names(self) -> dict[str, list[str]]:
-        """Available auxiliary source names grouped by category."""
+    def aux_sources(self) -> type[BaseModel] | None:
+        """
+        Pydantic model class for auxiliary sources.
+
+        Returns None if the workflow does not use auxiliary sources.
+        Field names define the aux source identifiers, and field types (typically
+        Literal or Enum) define the available stream choices.
+        """
+        return None
+
+    @property
+    def initial_aux_source_names(self) -> dict[str, str]:
+        """
+        Initially selected auxiliary source names.
+
+        Returns a mapping from field name (as defined in aux_sources model) to
+        the selected stream name.
+        """
         return {}
 
     @abstractmethod
@@ -54,10 +72,22 @@ class ConfigurationAdapter(ABC, Generic[Model]):
 
     @abstractmethod
     def start_action(
-        self, selected_sources: list[str], parameter_values: Model
+        self,
+        selected_sources: list[str],
+        parameter_values: Model,
+        aux_source_names: dict[str, str] | None = None,
     ) -> bool:
         """
         Execute the start action with selected sources and parameters.
+
+        Parameters
+        ----------
+        selected_sources
+            Selected source names
+        parameter_values
+            Parameter values
+        aux_source_names
+            Selected auxiliary source names (field name → stream name)
 
         Returns
         -------

--- a/src/ess/livedata/dashboard/correlation_histogram.py
+++ b/src/ess/livedata/dashboard/correlation_histogram.py
@@ -74,7 +74,7 @@ def make_workflow_spec(ndim: int) -> WorkflowSpec:
         version=1,
         description=f'{ndim}D correlation histogram workflow',
         source_names=[],
-        aux_source_names=[],
+        aux_sources=None,
         params=params[ndim],
     )
 

--- a/src/ess/livedata/dashboard/widgets/configuration_widget.py
+++ b/src/ess/livedata/dashboard/widgets/configuration_widget.py
@@ -10,6 +10,7 @@ import pydantic
 from ess.livedata.dashboard.configuration_adapter import ConfigurationAdapter
 
 from .model_widget import ModelWidget
+from .param_widget import ParamWidget
 
 
 class ConfigurationWidget:
@@ -26,7 +27,7 @@ class ConfigurationWidget:
         """
         self._config = config
         self._source_selector = self._create_source_selector()
-        self._aux_source_selectors = self._create_aux_source_selectors()
+        self._aux_sources_widget = self._create_aux_sources_widget()
         self._model_widget = self._create_model_widget()
         self._source_error_pane = pn.pane.HTML("", sizing_mode='stretch_width')
         self._widget = self._create_widget()
@@ -49,35 +50,35 @@ class ConfigurationWidget:
             margin=(0, 0, 0, 0),
         )
 
-    def _create_aux_source_selectors(self) -> dict[str, pn.widgets.Select]:
-        """Create auxiliary source selection widgets."""
-        selectors = {}
-        size = len(self._config.aux_source_names)
-        for i, (category, options) in enumerate(self._config.aux_source_names.items()):
-            if not options:
-                raise ValueError(
-                    f"Empty options list for aux source category '{category}'"
-                )
+    def _create_aux_sources_widget(self) -> ParamWidget | None:
+        """Create auxiliary sources widget using ParamWidget."""
+        aux_sources_model = self._config.aux_sources
+        if aux_sources_model is None:
+            return None
 
-            selector = pn.widgets.Select(
-                name=category,
-                options=options,
-                value=options[0],  # Default to first entry
-                sizing_mode='stretch_width',
-                # No left margin and no right margin for last item: Align with source
-                # selector above.
-                margin=(0, 0 if i == size - 1 else 10, 10, 0),
-            )
-            selector.param.watch(self._on_aux_source_changed, 'value')
-            selectors[category] = selector
-        return selectors
+        # Create ParamWidget for the aux_sources model
+        aux_widget = ParamWidget(aux_sources_model)
+
+        # Set initial values if available
+        initial_values = self._config.initial_aux_source_names
+        if initial_values:
+            aux_widget.set_values(initial_values)
+
+        # Watch for changes to trigger model_widget recreation
+        for widget in aux_widget.widgets.values():
+            # Handle both wrapped (bool) and unwrapped widgets
+            actual_widget = widget[0] if isinstance(widget, pn.Row) else widget
+            actual_widget.param.watch(self._on_aux_source_changed, 'value')
+
+        return aux_widget
 
     def _create_model_widget(self) -> ModelWidget | NoParamsWidget | ErrorWidget:
         """Create model widget based on current aux source selections."""
-        aux_selections = {
-            category: selector.value
-            for category, selector in self._aux_source_selectors.items()
-        }
+        # Get aux source selections from the ParamWidget
+        if self._aux_sources_widget is not None:
+            aux_selections = self._aux_sources_widget.get_values()
+        else:
+            aux_selections = {}
 
         try:
             model_class = self._config.model_class(aux_selections)
@@ -124,12 +125,9 @@ class ConfigurationWidget:
             self._source_error_pane,
         ]
 
-        # Add auxiliary source selectors if any exist
-        if self._aux_source_selectors:
-            aux_row = pn.Row(
-                *self._aux_source_selectors.values(), sizing_mode='stretch_width'
-            )
-            components.append(aux_row)
+        # Add auxiliary sources widget if it exists
+        if self._aux_sources_widget is not None:
+            components.append(self._aux_sources_widget.panel())
 
         components.append(self._model_widget.widget)
 
@@ -148,10 +146,10 @@ class ConfigurationWidget:
     @property
     def selected_aux_sources(self) -> dict[str, str]:
         """Get the selected auxiliary source names."""
-        return {
-            category: selector.value
-            for category, selector in self._aux_source_selectors.items()
-        }
+        if self._aux_sources_widget is None:
+            return {}
+        # Get values from ParamWidget and convert enum instances to their values
+        return self._aux_sources_widget.get_values()
 
     @property
     def parameter_values(self):
@@ -296,6 +294,7 @@ class ConfigurationModal:
         success = self._config.start_action(
             self._config_widget.selected_sources,
             self._config_widget.parameter_values,
+            self._config_widget.selected_aux_sources or None,
         )
 
         if not success:

--- a/src/ess/livedata/dashboard/widgets/param_widget.py
+++ b/src/ess/livedata/dashboard/widgets/param_widget.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, get_args, get_origin
 
 import panel as pn
 import pydantic
@@ -118,6 +118,15 @@ class ParamWidget:
             default_widget_value = (
                 default_value if default_value else next(iter(options.values()))
             )
+            return pn.widgets.Select(
+                options=options, value=default_widget_value, **shared_options
+            )
+        elif get_origin(field_type) is Literal:
+            # Handle Literal types (e.g., Literal['a', 'b', 'c'])
+            literal_values = get_args(field_type)
+            options = {str(val): val for val in literal_values}
+
+            default_widget_value = default_value if default_value else literal_values[0]
             return pn.widgets.Select(
                 options=options, value=default_widget_value, **shared_options
             )

--- a/src/ess/livedata/dashboard/widgets/plot_creation_widget.py
+++ b/src/ess/livedata/dashboard/widgets/plot_creation_widget.py
@@ -81,7 +81,12 @@ class PlotConfigurationAdapter(ConfigurationAdapter):
             return self._persisted_config.config.params
         return {}
 
-    def start_action(self, selected_sources: list[str], parameter_values: Any) -> bool:
+    def start_action(
+        self,
+        selected_sources: list[str],
+        parameter_values: Any,
+        aux_source_names: dict[str, str] | None = None,
+    ) -> bool:
         try:
             dmap = self._plotting_controller.create_plot(
                 job_number=self._job_number,

--- a/src/ess/livedata/dashboard/workflow_controller.py
+++ b/src/ess/livedata/dashboard/workflow_controller.py
@@ -7,7 +7,6 @@ Workflow controller implementation backed by a config service.
 from __future__ import annotations
 
 import logging
-import uuid
 from collections.abc import Callable, Mapping
 
 import pydantic
@@ -165,13 +164,12 @@ class WorkflowController:
             )
             return False
 
-        # We generate a new job number for the workflow. This will allow for associating
-        # multiple jobs with the same workflow run for different sources.
-        workflow_config = WorkflowConfig(
-            identifier=workflow_id,
-            job_number=uuid.uuid4(),
-            aux_source_names=aux_source_names or {},
-            params=config.model_dump(),
+        # Create workflow config. A new job number is generated to allow associating
+        # multiple jobs with the same workflow run across different sources.
+        workflow_config = WorkflowConfig.from_params(
+            workflow_id=workflow_id,
+            params=config,
+            aux_source_names=aux_source_names,
         )
 
         # Update the config for this workflow, used for restoring widget state

--- a/src/ess/livedata/handlers/workflow_factory.py
+++ b/src/ess/livedata/handlers/workflow_factory.py
@@ -72,12 +72,14 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
         def decorator(
             factory: Callable[..., Workflow],
         ) -> Callable[..., Workflow]:
-            # Try to get the type hint of the 'params' argument if it exists
-            # Use get_type_hints to resolve forward references, in case we used
-            # `from __future__ import annotations`.
+            # Try to get the type hints of the 'params' and 'aux_sources' arguments
+            # if they exist. Use get_type_hints to resolve forward references, in case
+            # we used `from __future__ import annotations`.
             type_hints = typing.get_type_hints(factory, globalns=factory.__globals__)
-            params_type = type_hints.get('params', None)
-            spec.params = params_type
+            if (params_type := type_hints.get('params', None)) is not None:
+                spec.params = params_type
+            if (aux_sources_type := type_hints.get('aux_sources', None)) is not None:
+                spec.aux_sources = aux_sources_type
             self._factories[spec_id] = factory
             self._workflow_specs[spec_id] = spec
             return factory
@@ -110,6 +112,16 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
         else:
             workflow_params = model_cls.model_validate(config.params)
 
+        if (aux_model_cls := workflow_spec.aux_sources) is None:
+            if config.aux_source_names:
+                raise ValueError(
+                    f"Workflow '{workflow_id}' does not require auxiliary sources, "
+                    f"but received: {config.aux_source_names}"
+                )
+            workflow_aux_sources = None
+        else:
+            workflow_aux_sources = aux_model_cls.model_validate(config.aux_source_names)
+
         if workflow_spec.source_names and source_name not in workflow_spec.source_names:
             allowed_sources = ", ".join(workflow_spec.source_names)
             raise ValueError(
@@ -127,6 +139,8 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
             kwargs['source_name'] = source_name
         if workflow_params and 'params' in sig.parameters:
             kwargs['params'] = workflow_params
+        if workflow_aux_sources and 'aux_sources' in sig.parameters:
+            kwargs['aux_sources'] = workflow_aux_sources
 
         # Call factory with appropriate arguments
         if kwargs:

--- a/tests/config/workflow_roundtrip_test.py
+++ b/tests/config/workflow_roundtrip_test.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""
+Test workflow registration → configuration → instantiation roundtrip.
+
+This test ensures that for each registered workflow:
+1. WorkflowSpec is properly created with params and aux_sources type hints
+2. Default values can be obtained from Pydantic models (via adapter)
+3. WorkflowConfig can be created from defaults (via from_params)
+4. Backend can instantiate the workflow from the config
+"""
+
+import uuid
+
+import pydantic
+import pytest
+
+from ess.livedata.config.instrument import instrument_registry
+from ess.livedata.config.instruments import available_instruments, get_config
+from ess.livedata.config.workflow_spec import WorkflowConfig, WorkflowId
+from ess.livedata.core.job_manager import JobFactory, JobId
+from ess.livedata.dashboard.workflow_configuration_adapter import (
+    WorkflowConfigurationAdapter,
+)
+
+
+def _collect_workflows():
+    """Collect all workflows from all instruments for parameterization."""
+    workflows = []
+    for instrument_name in available_instruments():
+        _ = get_config(instrument_name)  # Load module to register instrument
+        instrument = instrument_registry[instrument_name]
+        workflows.extend(
+            [
+                pytest.param(instrument_name, workflow_id, id=str(workflow_id))
+                for workflow_id in instrument.workflow_factory
+            ]
+        )
+    return workflows
+
+
+@pytest.mark.parametrize(("instrument_name", "workflow_id"), _collect_workflows())
+def test_workflow_roundtrip(instrument_name: str, workflow_id: WorkflowId):
+    """Test complete roundtrip for a registered workflow.
+
+    This test validates the chain:
+    1. Workflow registration creates proper WorkflowSpec with type hints
+    2. Default parameter values can be extracted via adapter
+    3. WorkflowConfig can be created using from_params helper
+    4. Backend can instantiate workflow from config (JobFactory)
+    """
+    # Skip known workflows that require data files not available in CI
+    if str(workflow_id) == "dream/data_reduction/powder_reduction_with_vanadium/1":
+        pytest.skip(
+            "Workflow requires vanadium data file "
+            "(268227_00024779_Vana_inc_BC_offset_240_deg_wlgth.hdf) "
+            "not available in test environment"
+        )
+
+    instrument = instrument_registry[instrument_name]
+    workflow_factory = instrument.workflow_factory
+
+    # Step 1: Verify WorkflowSpec was created with proper type hints
+    spec = workflow_factory[workflow_id]
+    assert spec is not None, f"WorkflowSpec not found for {workflow_id}"
+
+    # Step 2: Use WorkflowConfigurationAdapter to get model classes
+    # This simulates what the frontend (ConfigurationWidget) does
+    adapter = WorkflowConfigurationAdapter(
+        spec=spec,
+        persistent_config=None,  # No saved config, use defaults
+        start_callback=lambda *args, **kwargs: True,  # Dummy callback for testing
+    )
+
+    # Get parameter model class from adapter (like ConfigurationWidget does)
+    params_model = None
+    params_class = adapter.model_class({})  # Pass empty aux_source_names
+    if params_class is not None:
+        # Instantiate with defaults (ConfigurationWidget uses initial_parameter_values
+        # if available, otherwise creates with defaults)
+        params_model = params_class()
+
+    # Get aux sources from adapter (like ConfigurationWidget does)
+    aux_source_names = None
+    if adapter.aux_sources is not None:
+        # Instantiate with defaults
+        aux_sources_model = adapter.aux_sources()
+        aux_source_names = aux_sources_model.model_dump()
+
+    # Step 3: Create WorkflowConfig using the helper method
+    # This simulates what WorkflowController.start_workflow does
+    workflow_config = WorkflowConfig.from_params(
+        workflow_id=workflow_id,
+        params=params_model,
+        aux_source_names=aux_source_names,
+    )
+
+    # Step 4: Instantiate workflow via backend path (JobFactory → WorkflowFactory)
+    # Pick the first available source, or use empty string if none specified
+    source_name = spec.source_names[0] if spec.source_names else "test_source"
+
+    # Set active namespace to match the workflow namespace
+    # (in production this is set when the service starts)
+    original_namespace = instrument.active_namespace
+    instrument.active_namespace = workflow_id.namespace
+    try:
+        job_factory = JobFactory(instrument)
+        job_id = JobId(source_name=source_name, job_number=uuid.uuid4())
+
+        # This should not raise - it validates params and aux_sources internally
+        job = job_factory.create(job_id=job_id, config=workflow_config)
+    finally:
+        # Restore original namespace
+        instrument.active_namespace = original_namespace
+
+    # Verify job was created successfully
+    assert job is not None
+    assert job.job_id == job_id
+    assert job.workflow_id == workflow_id
+
+
+@pytest.mark.parametrize(("instrument_name", "workflow_id"), _collect_workflows())
+def test_workflow_spec_has_type_hints(instrument_name: str, workflow_id: WorkflowId):
+    """Test that WorkflowSpec has type hints extracted from factory function.
+
+    This verifies that the decorator in WorkflowFactory.register properly extracted
+    type hints and populated spec.params and spec.aux_sources.
+    """
+    instrument = instrument_registry[instrument_name]
+    spec = instrument.workflow_factory[workflow_id]
+
+    # Type hints should be extracted if factory has params/aux_sources arguments
+    # We can't easily check the factory signature here without accessing private state,
+    # but we can verify that if type hints exist, they're valid Pydantic models
+
+    if spec.params is not None:
+        assert issubclass(spec.params, pydantic.BaseModel), (
+            f"spec.params for {workflow_id} should be a Pydantic BaseModel subclass, "
+            f"got {spec.params}"
+        )
+        # Verify we can instantiate with defaults
+        instance = spec.params()
+        assert isinstance(instance, pydantic.BaseModel)
+
+    if spec.aux_sources is not None:
+        assert issubclass(spec.aux_sources, pydantic.BaseModel), (
+            f"spec.aux_sources for {workflow_id} should be a "
+            f"Pydantic BaseModel subclass, got {spec.aux_sources}"
+        )
+        # Verify we can instantiate with defaults
+        instance = spec.aux_sources()
+        assert isinstance(instance, pydantic.BaseModel)
+
+
+@pytest.mark.parametrize(("instrument_name", "workflow_id"), _collect_workflows())
+def test_workflow_params_serialization_roundtrip(
+    instrument_name: str, workflow_id: WorkflowId
+):
+    """Test that params can be serialized and deserialized without loss.
+
+    This simulates the frontend→backend→frontend cycle:
+    - Frontend creates params model with defaults
+    - WorkflowConfig.from_params serializes to dict (via model.model_dump())
+    - Backend deserializes from dict (model.model_validate(dict))
+    - Values should remain identical
+    """
+    instrument = instrument_registry[instrument_name]
+    spec = instrument.workflow_factory[workflow_id]
+
+    if spec.params is None:
+        pytest.skip("Workflow has no parameters")
+
+    # Create instance with defaults
+    original = spec.params()
+
+    # Simulate WorkflowConfig.from_params serialization
+    workflow_config = WorkflowConfig.from_params(
+        workflow_id=workflow_id,
+        params=original,
+    )
+    serialized = workflow_config.params
+
+    # Simulate backend deserialization (WorkflowFactory.create line 113)
+    deserialized = spec.params.model_validate(serialized)
+
+    # Should be identical after roundtrip
+    assert deserialized.model_dump() == original.model_dump()
+
+
+@pytest.mark.parametrize(("instrument_name", "workflow_id"), _collect_workflows())
+def test_workflow_aux_sources_serialization_roundtrip(
+    instrument_name: str, workflow_id: WorkflowId
+):
+    """Test that aux_sources can be serialized and deserialized without loss.
+
+    This simulates the frontend→backend cycle for auxiliary sources:
+    - Frontend creates aux_sources model with defaults
+    - WorkflowConfig.from_params stores as dict
+    - Backend deserializes from dict (model.model_validate(dict))
+    """
+    instrument = instrument_registry[instrument_name]
+    spec = instrument.workflow_factory[workflow_id]
+
+    if spec.aux_sources is None:
+        pytest.skip("Workflow has no auxiliary sources")
+
+    # Create instance with defaults
+    original = spec.aux_sources()
+
+    # Simulate WorkflowConfig.from_params storing aux sources
+    workflow_config = WorkflowConfig.from_params(
+        workflow_id=workflow_id,
+        aux_source_names=original.model_dump(),
+    )
+    serialized = workflow_config.aux_source_names
+
+    # Simulate backend deserialization (WorkflowFactory.create line 123)
+    deserialized = spec.aux_sources.model_validate(serialized)
+
+    # Should be identical after roundtrip
+    assert deserialized.model_dump() == original.model_dump()
+
+
+@pytest.mark.parametrize(("instrument_name", "workflow_id"), _collect_workflows())
+def test_workflow_config_widget_adapter_compatibility(
+    instrument_name: str, workflow_id: WorkflowId
+):
+    """Test that WorkflowSpec is compatible with WorkflowConfigurationAdapter.
+
+    This verifies that WorkflowConfigurationAdapter can be created and used
+    to extract default values, simulating what ConfigurationWidget does.
+    """
+    instrument = instrument_registry[instrument_name]
+    spec = instrument.workflow_factory[workflow_id]
+
+    # Create adapter (this is what WorkflowController.create_workflow_adapter does)
+    adapter = WorkflowConfigurationAdapter(
+        spec=spec,
+        persistent_config=None,
+        start_callback=lambda *args, **kwargs: True,
+    )
+
+    # Verify adapter properties work
+    assert adapter.title == spec.title
+    assert adapter.description == spec.description
+    assert adapter.source_names == spec.source_names
+    assert adapter.aux_sources == spec.aux_sources
+
+    # Verify we can get the model class
+    model_class = adapter.model_class({})
+    if spec.params is not None:
+        assert model_class == spec.params
+        # Verify we can instantiate with defaults
+        instance = model_class()
+        assert isinstance(instance, pydantic.BaseModel)
+    else:
+        assert model_class is None
+
+    # Verify aux_sources can be instantiated
+    if spec.aux_sources is not None:
+        aux_instance = spec.aux_sources()
+        assert isinstance(aux_instance, pydantic.BaseModel)

--- a/tests/config/workflow_spec_test.py
+++ b/tests/config/workflow_spec_test.py
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+from enum import Enum
+
 import pytest
+from pydantic import BaseModel, Field
 
 from ess.livedata.config.workflow_spec import (
     PersistentWorkflowConfig,
     PersistentWorkflowConfigs,
     WorkflowConfig,
     WorkflowId,
+    WorkflowSpec,
 )
 
 
@@ -70,3 +74,133 @@ class TestPersistentWorkflowConfig:
         dumped = configs.model_dump()
         loaded = PersistentWorkflowConfigs.model_validate(dumped)
         assert configs == loaded
+
+
+class TestWorkflowSpecAuxSources:
+    """Tests for WorkflowSpec.aux_sources field."""
+
+    def test_workflow_spec_without_aux_sources(self) -> None:
+        """Test that WorkflowSpec can be created without aux_sources."""
+        spec = WorkflowSpec(
+            instrument="test",
+            name="test_workflow",
+            version=1,
+            title="Test Workflow",
+            description="A test workflow",
+            params=None,
+        )
+        assert spec.aux_sources is None
+
+    def test_workflow_spec_with_aux_sources_model(self) -> None:
+        """Test WorkflowSpec with aux_sources as a Pydantic model."""
+
+        class MonitorChoice(str, Enum):
+            MONITOR1 = "monitor1"
+            MONITOR2 = "monitor2"
+
+        class AuxSources(BaseModel):
+            monitor: MonitorChoice = Field(
+                default=MonitorChoice.MONITOR1,
+                title="Monitor",
+                description="Select which monitor to use",
+            )
+
+        spec = WorkflowSpec(
+            instrument="test",
+            name="test_workflow",
+            version=1,
+            title="Test Workflow",
+            description="A test workflow",
+            params=None,
+            aux_sources=AuxSources,
+        )
+        assert spec.aux_sources is AuxSources
+
+    def test_workflow_spec_serialization_with_aux_sources(self) -> None:
+        """Test WorkflowSpec with aux_sources serialization."""
+
+        class AuxSources(BaseModel):
+            rotation: str = Field(title="Rotation", description="Select rotation")
+
+        spec = WorkflowSpec(
+            instrument="test",
+            name="test_workflow",
+            version=1,
+            title="Test Workflow",
+            description="A test workflow",
+            params=None,
+            aux_sources=AuxSources,
+        )
+
+        # Serialize and deserialize
+        dumped = spec.model_dump()
+        loaded = WorkflowSpec.model_validate(dumped)
+
+        assert loaded.aux_sources is not None
+        # Both should be the same class (not just equal instances)
+        assert loaded.aux_sources.__name__ == spec.aux_sources.__name__
+
+
+class TestWorkflowConfigAuxSourceNames:
+    """Tests for WorkflowConfig.aux_source_names field."""
+
+    def test_workflow_config_default_aux_source_names(
+        self, sample_workflow_id: WorkflowId
+    ) -> None:
+        """Test that WorkflowConfig has empty aux_source_names by default."""
+        config = WorkflowConfig(identifier=sample_workflow_id)
+        assert config.aux_source_names == {}
+
+    def test_workflow_config_with_aux_source_names(
+        self, sample_workflow_id: WorkflowId
+    ) -> None:
+        """Test that WorkflowConfig can store aux_source_names as dict."""
+        config = WorkflowConfig(
+            identifier=sample_workflow_id,
+            aux_source_names={"monitor": "monitor1", "rotation": "rotation_a"},
+        )
+        assert config.aux_source_names == {
+            "monitor": "monitor1",
+            "rotation": "rotation_a",
+        }
+
+    def test_workflow_config_serialization_with_aux_source_names(
+        self, sample_workflow_id: WorkflowId
+    ) -> None:
+        """Test that WorkflowConfig with aux_source_names serializes correctly."""
+        config = WorkflowConfig(
+            identifier=sample_workflow_id,
+            aux_source_names={"monitor": "monitor2"},
+            params={"param1": 10},
+        )
+
+        dumped = config.model_dump()
+        loaded = WorkflowConfig.model_validate(dumped)
+
+        assert loaded.aux_source_names == {"monitor": "monitor2"}
+        assert loaded.params == {"param1": 10}
+
+
+class TestPersistentWorkflowConfigWithAuxSources:
+    """Tests for PersistentWorkflowConfig with aux_source_names."""
+
+    def test_persistent_config_serialization_with_aux_sources(
+        self, sample_workflow_id: WorkflowId
+    ) -> None:
+        """Test that PersistentWorkflowConfig correctly serializes aux_source_names."""
+        config = WorkflowConfig(
+            identifier=sample_workflow_id,
+            aux_source_names={"monitor": "monitor1"},
+            params={"param1": 5},
+        )
+        pwc = PersistentWorkflowConfig(source_names=["source1"], config=config)
+
+        # Test serialization through PersistentWorkflowConfigs
+        configs = PersistentWorkflowConfigs(configs={sample_workflow_id: pwc})
+        dumped = configs.model_dump()
+        loaded = PersistentWorkflowConfigs.model_validate(dumped)
+
+        assert loaded.configs[sample_workflow_id].config.aux_source_names == {
+            "monitor": "monitor1"
+        }
+        assert loaded.configs[sample_workflow_id].config.params == {"param1": 5}

--- a/tests/core/job_manager_test.py
+++ b/tests/core/job_manager_test.py
@@ -28,7 +28,7 @@ class FakeJobFactory(JobFactory):
             workflow_id=config.identifier,
             processor=processor,
             source_names=[job_id.source_name],
-            aux_source_names=["aux_source"],
+            aux_source_names=config.aux_source_names,
         )
 
         self.created_jobs.append((job_id, config))

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -98,7 +98,7 @@ def sample_job(fake_processor: FakeProcessor, sample_workflow_id: WorkflowId):
         workflow_id=sample_workflow_id,
         processor=fake_processor,
         source_names=["test_source"],
-        aux_source_names=["aux_source"],
+        aux_source_names={"aux_source": "aux_source"},
     )
 
 
@@ -432,17 +432,17 @@ class TestJobAuxSourceMapping:
         assert accumulated["incident_monitor"] == sc.scalar(10.0)
         assert accumulated["transmission_monitor"] == sc.scalar(20.0)
 
-    def test_aux_sources_list_backward_compat(
+    def test_aux_sources_when_field_names_equal_stream_names(
         self, fake_processor: FakeProcessor, sample_workflow_id: WorkflowId
     ):
-        """Test backward compatibility: list means field names == stream names."""
+        """Test case where field names and stream names are identical."""
         job_id = JobId(source_name="detector1", job_number=1)
         job = Job(
             job_id=job_id,
             workflow_id=sample_workflow_id,
             processor=fake_processor,
             source_names=["detector1"],
-            aux_source_names=["monitor1", "monitor2"],  # Old list format
+            aux_source_names={"monitor1": "monitor1", "monitor2": "monitor2"},
         )
 
         # Send data with stream names
@@ -457,7 +457,7 @@ class TestJobAuxSourceMapping:
         )
         job.add(data)
 
-        # Verify workflow received data with same keys (backward compat)
+        # Verify workflow received data with same keys (field names == stream names)
         assert len(fake_processor.accumulate_calls) == 1
         accumulated = fake_processor.accumulate_calls[0]
         assert "monitor1" in accumulated

--- a/tests/dashboard/widgets/param_widget_test.py
+++ b/tests/dashboard/widgets/param_widget_test.py
@@ -1,0 +1,654 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+from enum import Enum
+from pathlib import Path
+from typing import Literal
+
+import panel as pn
+import pydantic
+import pytest
+
+from ess.livedata.dashboard.widgets.param_widget import ParamWidget, snake_to_camel
+
+
+class TestSnakeToCamel:
+    """Tests for snake_to_camel utility function."""
+
+    def test_single_word(self):
+        assert snake_to_camel("word") == "Word"
+
+    def test_two_words(self):
+        assert snake_to_camel("snake_case") == "SnakeCase"
+
+    def test_multiple_words(self):
+        assert snake_to_camel("multiple_word_example") == "MultipleWordExample"
+
+    def test_with_numbers(self):
+        assert snake_to_camel("test_123_value") == "Test123Value"
+
+    def test_already_camel(self):
+        assert snake_to_camel("CamelCase") == "Camelcase"
+
+
+class TestParamWidgetCreation:
+    """Tests for ParamWidget creation and initialization."""
+
+    def test_create_widget_with_basic_types(self):
+        class TestModel(pydantic.BaseModel):
+            int_field: int = 5
+            float_field: float = 3.14
+            str_field: str = "test"
+            bool_field: bool = True
+
+        widget = ParamWidget(TestModel)
+
+        assert len(widget.widgets) == 4
+        assert "int_field" in widget.widgets
+        assert "float_field" in widget.widgets
+        assert "str_field" in widget.widgets
+        assert "bool_field" in widget.widgets
+
+    def test_widget_has_layout(self):
+        class TestModel(pydantic.BaseModel):
+            field: int = 1
+
+        widget = ParamWidget(TestModel)
+
+        assert hasattr(widget, "layout")
+        assert isinstance(widget.layout, pn.Column)
+
+    def test_widget_has_error_pane(self):
+        class TestModel(pydantic.BaseModel):
+            field: int = 1
+
+        widget = ParamWidget(TestModel)
+
+        assert hasattr(widget, "_error_pane")
+        assert isinstance(widget._error_pane, pn.pane.HTML)
+
+
+class TestWidgetTypeCreation:
+    """Tests for creating appropriate widget types for different field types."""
+
+    def test_int_field_creates_int_input(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = 5
+
+        widget = ParamWidget(TestModel)
+
+        assert isinstance(widget.widgets["value"], pn.widgets.IntInput)
+        assert widget.widgets["value"].value == 5
+
+    def test_float_field_creates_float_input(self):
+        class TestModel(pydantic.BaseModel):
+            value: float = 3.14
+
+        widget = ParamWidget(TestModel)
+
+        assert isinstance(widget.widgets["value"], pn.widgets.FloatInput)
+        assert widget.widgets["value"].value == 3.14
+
+    def test_str_field_creates_text_input(self):
+        class TestModel(pydantic.BaseModel):
+            value: str = "test"
+
+        widget = ParamWidget(TestModel)
+
+        assert isinstance(widget.widgets["value"], pn.widgets.TextInput)
+        assert widget.widgets["value"].value == "test"
+
+    def test_bool_field_creates_checkbox_in_row(self):
+        class TestModel(pydantic.BaseModel):
+            value: bool = True
+
+        widget = ParamWidget(TestModel)
+
+        # Boolean widgets are wrapped in a Row
+        assert isinstance(widget.widgets["value"], pn.Row)
+        checkbox = widget.widgets["value"][0]
+        assert isinstance(checkbox, pn.widgets.Checkbox)
+        assert checkbox.value is True
+
+    def test_path_field_creates_text_input(self):
+        class TestModel(pydantic.BaseModel):
+            value: Path = Path("/tmp/test")  # noqa: S108
+
+        widget = ParamWidget(TestModel)
+
+        assert isinstance(widget.widgets["value"], pn.widgets.TextInput)
+        assert widget.widgets["value"].value == "/tmp/test"  # noqa: S108
+
+    def test_enum_field_creates_select(self):
+        class Color(str, Enum):
+            RED = "red"
+            BLUE = "blue"
+            GREEN = "green"
+
+        class TestModel(pydantic.BaseModel):
+            color: Color = Color.RED
+
+        widget = ParamWidget(TestModel)
+
+        assert isinstance(widget.widgets["color"], pn.widgets.Select)
+        assert widget.widgets["color"].value == Color.RED
+
+    def test_literal_field_creates_select(self):
+        class TestModel(pydantic.BaseModel):
+            choice: Literal["a", "b", "c"] = "a"
+
+        widget = ParamWidget(TestModel)
+
+        assert isinstance(widget.widgets["choice"], pn.widgets.Select)
+        assert widget.widgets["choice"].value == "a"
+
+    def test_optional_field_extracts_type(self):
+        class TestModel(pydantic.BaseModel):
+            value: int | None = None
+
+        widget = ParamWidget(TestModel)
+
+        # Should still create an IntInput, not a TextInput fallback
+        assert isinstance(widget.widgets["value"], pn.widgets.IntInput)
+
+
+class TestWidgetDefaultValues:
+    """Tests for widget default values."""
+
+    def test_uses_pydantic_default_for_int(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = 42
+
+        widget = ParamWidget(TestModel)
+
+        assert widget.widgets["value"].value == 42
+
+    def test_uses_zero_when_no_default_for_int(self):
+        class TestModel(pydantic.BaseModel):
+            value: int
+
+        widget = ParamWidget(TestModel)
+
+        assert widget.widgets["value"].value == 0
+
+    def test_uses_zero_for_float_when_no_default(self):
+        class TestModel(pydantic.BaseModel):
+            value: float
+
+        widget = ParamWidget(TestModel)
+
+        assert widget.widgets["value"].value == 0.0
+
+    def test_uses_empty_string_when_no_default_for_str(self):
+        class TestModel(pydantic.BaseModel):
+            value: str
+
+        widget = ParamWidget(TestModel)
+
+        assert widget.widgets["value"].value == ""
+
+    def test_uses_false_when_no_default_for_bool(self):
+        class TestModel(pydantic.BaseModel):
+            value: bool
+
+        widget = ParamWidget(TestModel)
+
+        checkbox = widget.widgets["value"][0]
+        assert checkbox.value is False
+
+
+class TestWidgetLabelsAndDescriptions:
+    """Tests for widget labels and descriptions."""
+
+    def test_field_name_converted_to_camel_case(self):
+        class TestModel(pydantic.BaseModel):
+            my_field_name: int = 1
+
+        widget = ParamWidget(TestModel)
+
+        assert widget.widgets["my_field_name"].name == "MyFieldName"
+
+    def test_field_description_used(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = pydantic.Field(default=1, description="Test description")
+
+        widget = ParamWidget(TestModel)
+
+        assert widget.widgets["value"].description == "Test description"
+
+    def test_field_name_used_when_no_description(self):
+        class TestModel(pydantic.BaseModel):
+            my_value: int = 1
+
+        widget = ParamWidget(TestModel)
+
+        assert widget.widgets["my_value"].description == "my_value"
+
+    def test_bool_field_with_description_creates_tooltip(self):
+        class TestModel(pydantic.BaseModel):
+            flag: bool = pydantic.Field(default=True, description="A flag")
+
+        widget = ParamWidget(TestModel)
+
+        row = widget.widgets["flag"]
+        assert isinstance(row, pn.Row)
+        # Should have checkbox and tooltip
+        assert len(row) == 2
+        assert isinstance(row[0], pn.widgets.Checkbox)
+        assert isinstance(row[1], pn.widgets.TooltipIcon)
+
+
+class TestWidgetFrozenFields:
+    """Tests for frozen/disabled fields."""
+
+    def test_frozen_field_is_disabled(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = pydantic.Field(default=5, frozen=True)
+
+        widget = ParamWidget(TestModel)
+
+        assert widget.widgets["value"].disabled is True
+
+    def test_non_frozen_field_is_not_disabled(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = 5
+
+        widget = ParamWidget(TestModel)
+
+        assert widget.widgets["value"].disabled is False
+
+
+class TestEnumHandling:
+    """Tests for enum field handling."""
+
+    def test_string_enum_uses_values_as_display_keys(self):
+        class Status(str, Enum):
+            ACTIVE = "active"
+            INACTIVE = "inactive"
+
+        class TestModel(pydantic.BaseModel):
+            status: Status = Status.ACTIVE
+
+        widget = ParamWidget(TestModel)
+
+        select = widget.widgets["status"]
+        # For string enums, the display keys should be the string values
+        assert "active" in select.options
+        assert "inactive" in select.options
+
+    def test_int_enum_uses_member_names_as_display_keys(self):
+        class Priority(Enum):
+            LOW = 1
+            MEDIUM = 2
+            HIGH = 3
+
+        class TestModel(pydantic.BaseModel):
+            priority: Priority = Priority.LOW
+
+        widget = ParamWidget(TestModel)
+
+        select = widget.widgets["priority"]
+        # For non-string enums, display keys are member names
+        assert "LOW" in select.options
+        assert "MEDIUM" in select.options
+        assert "HIGH" in select.options
+
+
+class TestLiteralHandling:
+    """Tests for Literal type handling."""
+
+    def test_literal_creates_select_with_options(self):
+        class TestModel(pydantic.BaseModel):
+            mode: Literal["fast", "normal", "slow"] = "normal"
+
+        widget = ParamWidget(TestModel)
+
+        select = widget.widgets["mode"]
+        assert isinstance(select, pn.widgets.Select)
+        assert "fast" in select.options
+        assert "normal" in select.options
+        assert "slow" in select.options
+        assert select.value == "normal"
+
+
+class TestGetValues:
+    """Tests for get_values method."""
+
+    def test_get_values_returns_dict(self):
+        class TestModel(pydantic.BaseModel):
+            a: int = 1
+            b: float = 2.0
+
+        widget = ParamWidget(TestModel)
+        values = widget.get_values()
+
+        assert isinstance(values, dict)
+        assert "a" in values
+        assert "b" in values
+
+    def test_get_values_returns_current_widget_values(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = 5
+
+        widget = ParamWidget(TestModel)
+        widget.widgets["value"].value = 42
+
+        values = widget.get_values()
+        assert values["value"] == 42
+
+    def test_get_values_handles_bool_wrapped_in_row(self):
+        class TestModel(pydantic.BaseModel):
+            flag: bool = True
+
+        widget = ParamWidget(TestModel)
+        values = widget.get_values()
+
+        assert values["flag"] is True
+
+    def test_get_values_converts_path_string_to_path(self):
+        class TestModel(pydantic.BaseModel):
+            path: Path = Path("/tmp")  # noqa: S108
+
+        widget = ParamWidget(TestModel)
+        widget.widgets["path"].value = "/home/user"
+
+        values = widget.get_values()
+        assert isinstance(values["path"], Path)
+        assert values["path"] == Path("/home/user")
+
+    def test_get_values_handles_empty_path_string(self):
+        class TestModel(pydantic.BaseModel):
+            path: Path
+
+        widget = ParamWidget(TestModel)
+        widget.widgets["path"].value = ""
+
+        values = widget.get_values()
+        assert values["path"] is None
+
+    def test_get_values_returns_enum_instance(self):
+        class Color(str, Enum):
+            RED = "red"
+            BLUE = "blue"
+
+        class TestModel(pydantic.BaseModel):
+            color: Color = Color.RED
+
+        widget = ParamWidget(TestModel)
+        widget.widgets["color"].value = Color.BLUE
+
+        values = widget.get_values()
+        assert values["color"] == Color.BLUE
+        assert isinstance(values["color"], Color)
+
+
+class TestSetValues:
+    """Tests for set_values method."""
+
+    def test_set_values_updates_widgets(self):
+        class TestModel(pydantic.BaseModel):
+            a: int = 1
+            b: float = 2.0
+            c: str = "test"
+
+        widget = ParamWidget(TestModel)
+        widget.set_values({"a": 42, "b": 3.14, "c": "updated"})
+
+        assert widget.widgets["a"].value == 42
+        assert widget.widgets["b"].value == 3.14
+        assert widget.widgets["c"].value == "updated"
+
+    def test_set_values_handles_bool_wrapped_in_row(self):
+        class TestModel(pydantic.BaseModel):
+            flag: bool = False
+
+        widget = ParamWidget(TestModel)
+        widget.set_values({"flag": True})
+
+        checkbox = widget.widgets["flag"][0]
+        assert checkbox.value is True
+
+    def test_set_values_converts_path_to_string(self):
+        class TestModel(pydantic.BaseModel):
+            path: Path = Path("/tmp")  # noqa: S108
+
+        widget = ParamWidget(TestModel)
+        widget.set_values({"path": Path("/home/user")})
+
+        assert widget.widgets["path"].value == "/home/user"
+
+    def test_set_values_handles_enum_values(self):
+        class Color(str, Enum):
+            RED = "red"
+            BLUE = "blue"
+
+        class TestModel(pydantic.BaseModel):
+            color: Color = Color.RED
+
+        widget = ParamWidget(TestModel)
+        widget.set_values({"color": "blue"})
+
+        assert widget.widgets["color"].value == Color.BLUE
+
+    def test_set_values_ignores_unknown_fields(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = 1
+
+        widget = ParamWidget(TestModel)
+        # Should not raise error for unknown field
+        widget.set_values({"value": 42, "unknown_field": 99})
+
+        assert widget.widgets["value"].value == 42
+
+
+class TestCreateModel:
+    """Tests for create_model method."""
+
+    def test_create_model_returns_valid_model(self):
+        class TestModel(pydantic.BaseModel):
+            a: int = 1
+            b: float = 2.0
+
+        widget = ParamWidget(TestModel)
+        model = widget.create_model()
+
+        assert isinstance(model, TestModel)
+        assert model.a == 1
+        assert model.b == 2.0
+
+    def test_create_model_uses_current_widget_values(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = 5
+
+        widget = ParamWidget(TestModel)
+        widget.widgets["value"].value = 42
+
+        model = widget.create_model()
+        assert model.value == 42
+
+    def test_create_model_raises_validation_error_for_invalid_values(self):
+        class TestModel(pydantic.BaseModel):
+            positive: int = pydantic.Field(gt=0)
+
+        widget = ParamWidget(TestModel)
+        widget.widgets["positive"].value = -5
+
+        with pytest.raises(pydantic.ValidationError):
+            widget.create_model()
+
+
+class TestValidate:
+    """Tests for validate method."""
+
+    def test_validate_returns_true_for_valid_values(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = pydantic.Field(gt=0)
+
+        widget = ParamWidget(TestModel)
+        widget.widgets["value"].value = 5
+
+        is_valid, message = widget.validate()
+        assert is_valid is True
+        assert message == "Valid"
+
+    def test_validate_returns_false_for_invalid_values(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = pydantic.Field(gt=0)
+
+        widget = ParamWidget(TestModel)
+        widget.widgets["value"].value = -5
+
+        is_valid, message = widget.validate()
+        assert is_valid is False
+        assert "value" in message
+
+    def test_validate_does_not_create_model(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = 5
+
+        widget = ParamWidget(TestModel)
+        original_value = widget.widgets["value"].value
+
+        widget.validate()
+        # Widget value should remain unchanged
+        assert widget.widgets["value"].value == original_value
+
+
+class TestSetErrorState:
+    """Tests for set_error_state method."""
+
+    def test_set_error_state_shows_error_message(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = 1
+
+        widget = ParamWidget(TestModel)
+        widget.set_error_state(True, "Test error")
+
+        assert "Test error" in widget._error_pane.object
+
+    def test_set_error_state_clears_error_message(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = 1
+
+        widget = ParamWidget(TestModel)
+        widget.set_error_state(True, "Test error")
+        widget.set_error_state(False, "")
+
+        assert widget._error_pane.object == ""
+
+    def test_set_error_state_highlights_failing_field(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = pydantic.Field(gt=0)
+
+        widget = ParamWidget(TestModel)
+        widget.widgets["value"].value = -5
+        widget.set_error_state(True, "value: must be greater than 0")
+
+        # Field should have error border
+        assert "border" in widget.widgets["value"].styles
+        assert "#dc3545" in widget.widgets["value"].styles["border"]
+
+    def test_set_error_state_clears_field_highlighting(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = pydantic.Field(gt=0)
+
+        widget = ParamWidget(TestModel)
+        widget.widgets["value"].value = -5
+        widget.set_error_state(True, "Test error")
+        widget.widgets["value"].value = 5
+        widget.set_error_state(False, "")
+
+        # Field should have no border
+        assert widget.widgets["value"].styles.get("border") == "none"
+
+
+class TestPanel:
+    """Tests for panel method."""
+
+    def test_panel_returns_layout(self):
+        class TestModel(pydantic.BaseModel):
+            value: int = 1
+
+        widget = ParamWidget(TestModel)
+        panel = widget.panel()
+
+        assert panel is widget.layout
+        assert isinstance(panel, pn.Column)
+
+
+class TestComplexModels:
+    """Tests for complex model scenarios."""
+
+    def test_multiple_field_types(self):
+        class Color(str, Enum):
+            RED = "red"
+            BLUE = "blue"
+
+        class ComplexModel(pydantic.BaseModel):
+            name: str = "test"
+            count: int = 10
+            ratio: float = 0.5
+            enabled: bool = True
+            color: Color = Color.RED
+            path: Path = Path("/tmp")  # noqa: S108
+            mode: Literal["fast", "slow"] = "fast"
+
+        widget = ParamWidget(ComplexModel)
+
+        assert len(widget.widgets) == 7
+        model = widget.create_model()
+        assert isinstance(model, ComplexModel)
+
+    def test_model_with_validation_constraints(self):
+        class ConstrainedModel(pydantic.BaseModel):
+            positive_int: int = pydantic.Field(gt=0, description="Must be positive")
+            bounded_float: float = pydantic.Field(ge=0.0, le=1.0)
+            non_empty_str: str = pydantic.Field(min_length=1)
+
+        widget = ParamWidget(ConstrainedModel)
+        widget.widgets["positive_int"].value = 5
+        widget.widgets["bounded_float"].value = 0.75
+        widget.widgets["non_empty_str"].value = "test"
+
+        model = widget.create_model()
+        assert model.positive_int == 5
+        assert model.bounded_float == 0.75
+        assert model.non_empty_str == "test"
+
+    def test_model_with_optional_fields(self):
+        class OptionalModel(pydantic.BaseModel):
+            required: int
+            optional_int: int | None = None
+            optional_str: str | None = None
+
+        widget = ParamWidget(OptionalModel)
+        widget.widgets["required"].value = 42
+
+        model = widget.create_model()
+        assert model.required == 42
+        assert model.optional_int is None or model.optional_int == 0
+        assert model.optional_str is None or model.optional_str == ""
+
+    def test_roundtrip_get_and_set_values(self):
+        class TestModel(pydantic.BaseModel):
+            a: int = 1
+            b: float = 2.0
+            c: str = "test"
+            d: bool = True
+
+        widget = ParamWidget(TestModel)
+        original_values = widget.get_values()
+
+        # Modify values
+        widget.set_values({"a": 42, "b": 3.14, "c": "modified", "d": False})
+        modified_values = widget.get_values()
+
+        assert modified_values["a"] == 42
+        assert modified_values["b"] == 3.14
+        assert modified_values["c"] == "modified"
+        assert modified_values["d"] is False
+
+        # Set back to original
+        widget.set_values(original_values)
+        restored_values = widget.get_values()
+
+        assert restored_values == original_values

--- a/tests/services/data_reduction_test.py
+++ b/tests/services/data_reduction_test.py
@@ -126,7 +126,13 @@ def test_can_configure_and_stop_workflow_with_detector_and_monitors(
     config_key = ConfigKey(
         source_name=source_name, service_name="data_reduction", key="workflow_config"
     )
-    workflow_config = workflow_spec.WorkflowConfig(identifier=workflow_id)
+    # Get default aux_source_names from the workflow spec
+    aux_source_names = {}
+    if spec.aux_sources is not None:
+        aux_source_names = spec.aux_sources().model_dump()
+    workflow_config = workflow_spec.WorkflowConfig(
+        identifier=workflow_id, aux_source_names=aux_source_names
+    )
     # Trigger workflow start
     app.publish_config_message(key=config_key, value=workflow_config.model_dump())
     service.step()


### PR DESCRIPTION
## Summary
Refactor `WorkflowSpec` auxiliary source configuration from simple list to structured Pydantic models with type hints, enabling more flexible configuration with titles, descriptions, and validation. Includes comprehensive test coverage and bug fixes discovered during implementation.

A key motivation for this was that it will be needed for ROI support.

## Key Changes

### 1. Core Schema Refactoring
- **Changed** `WorkflowSpec.aux_source_names: list[str]` → `aux_sources: type[BaseModel] | None`
- **Changed** `WorkflowConfig.aux_source_names` to use `dict[str, str]` format (field name → stream name)
- **Added** automatic type hint detection in `WorkflowFactory.register()` (similar to params)
- **Updated** all instrument workflows (DREAM, Bifrost, LOKI) to use new schema

### 2. Dashboard Integration
- **Extended** `ParamWidget` to support `Literal` types for aux_sources dropdowns
- **Integrated** aux_sources configuration into `ConfigurationWidget` UI
- **Updated** `WorkflowController` to handle new dict-based aux_sources format
- **Improved** encapsulation: extracted `WorkflowConfig.from_params()` class method

### 3. Bug Fixes
- **Fixed** variable shadowing in [loki.py](src/ess/livedata/config/instruments/loki.py) where `params` parameter shadowed `sans.types` module import (would have caused `AttributeError` at runtime)

### 4. Testing
- Added end-to-end validation of registration → configuration → instantiation chain (which goes beyond what was needed/changed here)

Resolves #501